### PR TITLE
chore: Update `composer.json` to indicate the library fulfills `psr/event-dispatcher-implementation`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "hyperf/contract": "~3.0.0",
         "psr/event-dispatcher": "^1.0"
     },
+    "provide": {
+        "psr/event-dispatcher-implementation": "1.0"
+    },
     "suggest": {
         "hyperf/di": "Required to use annotatioins."
     },


### PR DESCRIPTION
Hello! 👋 I've prepared this pull request to address something I noticed with my implementation of this library in the Okta/Auth0 PHP SDK libraries. At present, this library doesn't promote itself as being [a provider](https://packagist.org/providers/psr/event-dispatcher-implementation) of PSR-14's `psr/event-dispatcher-implmentation`.

This means that, in projects that expect a PSR-14 implementation to be available, Composer will throw an error for unresolved requirements, even with `hyperf/event` already available. The library appears to fulfill all the obligations of the implementation interface, so I'd see no reason why this shouldn't be considered a provider.

Thanks for your consideration! 🙇‍♂️